### PR TITLE
fix: enforce secure idempotency keys and remove deprecated webhook verification

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -57,11 +57,12 @@ export class PayArk {
      *
      * @example
      * ```ts
-     * const isValid = await PayArk.webhooks.verify(
+     * const event = await PayArk.webhooks.constructEvent(
      *   rawBody,
      *   req.headers['x-payark-signature'],
      *   process.env.PAYARK_WEBHOOK_SECRET!,
      * );
+     * console.log(event.type);
      * ```
      */
     static readonly webhooks = new WebhooksResource();

--- a/src/http.ts
+++ b/src/http.ts
@@ -13,7 +13,7 @@
 // higher-level PayArk client class.
 // ---------------------------------------------------------------------------
 
-import { PayArkError } from "./errors";
+import { PayArkError, PayArkConnectionError } from "./errors";
 import type { PayArkConfig, PayArkErrorBody } from "./types";
 
 /** SDK version – injected at build time for User-Agent header. */
@@ -262,7 +262,7 @@ export class HttpClient {
     return headers;
   }
 
-  /** Generate a unique idempotency key (UUID v4-like without crypto dep). */
+  /** Generate a unique idempotency key using cryptographically secure randomness. */
   private generateIdempotencyKey(): string {
     // Use crypto.randomUUID if available (Node 19+, all modern browsers, Bun)
     if (
@@ -271,8 +271,10 @@ export class HttpClient {
     ) {
       return crypto.randomUUID();
     }
-    // Fallback: timestamp + random hex (sufficient for idempotency, not crypto)
-    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+    throw new PayArkConnectionError(
+      "Secure random number generation is not available. Ensure your environment supports crypto.randomUUID().",
+    );
   }
 
   /** Promise-based sleep utility. */

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -10,7 +10,7 @@
 //   ```ts
 //   import { PayArk } from '@payark/sdk';
 //
-//   const isValid = await PayArk.webhooks.verify(
+//   const event = await PayArk.webhooks.constructEvent(
 //     rawBody,                            // The raw request body string
 //     request.headers['x-payark-signature'], // The signature header
 //     'whsec_...',                        // Your webhook secret
@@ -76,28 +76,6 @@ export class WebhooksResource {
       toleranceSeconds,
     );
     return JSON.parse(rawBody) as WebhookEvent;
-  }
-
-  /**
-   * @deprecated Use `constructEvent` instead.
-   */
-  async verify(
-    rawBody: string,
-    signatureHeader: string,
-    secret: string,
-    toleranceSeconds: number = DEFAULT_TOLERANCE_SECONDS,
-  ): Promise<boolean> {
-    try {
-      await this.verifySignature(
-        rawBody,
-        signatureHeader,
-        secret,
-        toleranceSeconds,
-      );
-      return true;
-    } catch {
-      return false;
-    }
   }
 
   /** Helper to perform the actual verification check. */


### PR DESCRIPTION
Enforced secure random number generation for idempotency keys using crypto.randomUUID and removed the deprecated verify method from WebhooksResource to comply with security requirements and API surface reduction.

---
*PR created automatically by Jules for task [7907416364328385251](https://jules.google.com/task/7907416364328385251) started by @Codimow*